### PR TITLE
Parser fixes

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
+++ b/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
@@ -32,6 +32,9 @@ class CommandLineArguments {
     @Parameter(names = { "-i", "--inlineVersStatus" }, description = "Show verse status as a footnote at the beginning of the verse.")
     boolean m_inlineVerseStatus = false;
 
+    @Parameter(names= { "-l", "--lax"}, description = "Use lax rules for parsing (prefer getting an export file to finding errors)")
+    boolean m_laxParsing = false;
+
     @Parameter(names = {"-h", "--help"})
     boolean m_help;
 }

--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -294,6 +294,9 @@ public class Exporter
         StringBuilder errorList = new StringBuilder();
         for(Book book : books) {
             for(Chapter chapter : book.chapters) {
+                if (m_commandLineArguments.m_laxParsing) {
+                    parser.setLaxChapter(book.wikiName + " " + chapter.number);
+                }
                 boolean success = chapter.generateAst(parser, parseRunner);
                 if(false == success && reloadOnError) {
                     reloadOnError = false;


### PR DESCRIPTION
- Unter Windows verwendet Java in der Regel als Standardzeichensatz kein UTF-8. Daher hier eine Korrektur für die Batchdatei, die den Zeichensatz auf UTF-8 ändert, da die Cachedateien ansonsten Information (Hebräisch, Griechisch) verlieren.
- Der Konverter kommt mit einigen Dingen (z. B. alphabetischen Unterversnummern, `<nowiki>`-Tags, Fußnoten in Überschriften, Zitate 3. Ebene oder Zitate in `<poem>`-Tags, leeren Fußnoten) nicht klar; diese werden aber verwendet.
