### PR TITLE
Regex argument of String.replaceAll() would need character escaping.

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -391,7 +391,7 @@ public class Exporter
         String result = Misc.readFile(leseFassung ? m_leseFassungTemplate : m_studienFassungTemplate);
 
         String dateString = new SimpleDateFormat("yyyy.MM.dd'T'kk.mm.ss").format(Calendar.getInstance().getTime());
-        result = result.replaceAll("{{date}}", "" + dateString);
+        result = result.replace("{{date}}", "" + dateString);
         result = result.replace("{{content}}", osisText);
         return result;
     }


### PR DESCRIPTION
The adjustment for inserting the date into OSIS output would break the conversion run by exception java.util.regex.PatternSyntaxException: Illegal repetition {, since String.replaceAll()s first argument is a regex expression and '{' a special character, so the expression would need to be escaped as "\\{\\{date\\}\\}", while String.replace() is already capable of replacing multiple occurrences of a search string.
