### PR TITLE
Add option to use previous versions

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
+++ b/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
@@ -17,6 +17,9 @@ class CommandLineArguments {
     @Parameter(names = { "-c", "--continueOnError" }, description = "If an error occurs, skip that chapter and continue.")
     boolean m_continueOnError = false;
 
+    @Parameter(names = { "-p", "--tryPreviousVersions" }, description = "If an error occurs, try to load a previous version of that chapter and retry.")
+    boolean m_tryPreviousVersions = false;
+
     @Parameter(names = { "--skipGenerateOSIS" }, description = "Skip generation of OSIS documents.")
     boolean m_skipGenerateOsis = false;
 

--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -7,15 +7,22 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.security.MessageDigest;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Vector;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
 
 import offeneBibel.parser.ObAstFixuper;
 import offeneBibel.parser.ObAstNode;
@@ -31,6 +38,10 @@ import org.parboiled.parserunners.RecoveringParseRunner;
 import org.parboiled.parserunners.ReportingParseRunner;
 import org.parboiled.parserunners.TracingParseRunner;
 import org.parboiled.support.ParsingResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 import util.Misc;
 
@@ -43,6 +54,17 @@ public class Exporter
      */
     //static final String m_urlBase = "http://www.offene-bibel.de/wiki/api.php?action=query&prop=revisions&rvprop=content&format=xml&titles=";
     static final String m_urlBase = "http://www.offene-bibel.de/wiki/index.php5?action=raw&title=";
+
+    /**
+     * URL prefix to use for retrieving history of a page.
+     */
+    static final String m_historyURLBase = "http://www.offene-bibel.de/wiki/api.php5?action=query&prop=revisions&rvprop=ids|timestamp&rvlimit=100&format=xml&titles=";
+
+    /**
+     * Oldest date for a history page to be considered to be retrieved. Increase it when parsing succeeded to find errors faster.
+     */
+    static final String m_minHistoryDate = "2015-01-01";
+
     /**
      * A list of all bible books as they are named on the wiki.
      * It was created by combining the wiki page: Vorlage:Kapitelzahl and the OSIS 2.1.1 manual Appendix C.1
@@ -277,6 +299,35 @@ public class Exporter
                     reloadOnError = false;
                     chapter.retrieveWikiPage(true);
                     success = chapter.generateAst(parser, parseRunner);
+                }
+                if (false == success && m_commandLineArguments.m_tryPreviousVersions) {
+                    String wikiPage = chapter.book.urlName + "_" + chapter.number;
+                    List<Integer> ids = new ArrayList<Integer>();
+                    String revisions = Misc.retrieveUrl(m_historyURLBase + URLEncoder.encode(wikiPage, "UTF-8"));
+                    Document revisionsXML = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(new StringReader(revisions)));
+                    NodeList revisionNodes = (NodeList) XPathFactory.newInstance().newXPath().evaluate("/api/query/pages/page/revisions/rev", revisionsXML, XPathConstants.NODESET);
+                    for(int i=0; i < revisionNodes.getLength(); i++) {
+                        Element revision = (Element) revisionNodes.item(i);
+                        if (revision.getAttribute("timestamp").compareTo(m_minHistoryDate) < 0)
+                            break;
+                        ids.add(Integer.parseInt(revision.getAttribute("revid")));
+                    }
+                    ids.add(-1); // make sure there is an (invalid, therefore empty) revision at the end of the list
+                    String fileCacheString = Misc.getPageCacheDir() + wikiPage;
+                    for(int id : ids) {
+                        try {
+                            String result = Misc.retrieveUrl(m_urlBase + URLEncoder.encode(wikiPage, "UTF-8")+"&oldid="+id);
+                            Misc.writeFile(result, fileCacheString);
+                            System.out.println(wikiPage+"@"+id);
+                        } catch (IOException e) {
+                            Misc.writeFile("", fileCacheString);
+                            System.out.println(wikiPage+"@"+id+" failed");
+                        }
+                        chapter.retrieveWikiPage(false);
+                        success = chapter.generateAst(parser, parseRunner);
+                        if (success)
+                            break;
+                    }
                 }
                 if(false == success) {
                     if(stopOnError) {


### PR DESCRIPTION
When parsing fails, and the new -p option is given, try to retrieve the
previous version of the wiki page and parse it instead. This continues
until either there are no more revision, or the revision is older than
minHistoryDate (currently 2015-01-01). In that case, an empty page (just
as if the article did not exist yet) is used.

That way, it should be (unless the parser is changed in incompatible ways)
always possible to create a (best-effort) export file containing as many
and as recent chapters as possible.

The retrieved previous page overwrites the cached page in the page cache;
therefore the history walk will not happen again when re-running without
purging the page cache.
