### PR TITLE
Improve Logos export

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
+++ b/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
@@ -389,7 +389,7 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
         public void visitAfter(ObAstNode hostNode) throws Throwable {}
     }
 
-    class NoteIndexCounter {
+    public static class NoteIndexCounter {
         private String m_noteIndexCounter;
 
         public NoteIndexCounter()


### PR DESCRIPTION
- Use fixed font "Times New Roman"  [makes Logos use the configured preferred font]
- Mark Greek and Hebrew text (based on Unicode scripts)
- Use letters for footnotes

[Getestet und von Ben für gut befunden]
