### PR TITLE
Kommandozeilenparameter um Bücher auszuwählen, und mehr

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
+++ b/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
@@ -1,5 +1,6 @@
 package offeneBibel.osisExporter;
 
+import util.ValidateBook;
 import util.ValidateLevel;
 import util.ValidateRunner;
 
@@ -8,6 +9,9 @@ import com.beust.jcommander.Parameter;
 class CommandLineArguments {
     @Parameter(names = { "-e", "--exportLevel" }, description = "Required translation status for export, 0=no restrictions on criteria, 7=all criteria met", validateWith=ValidateLevel.class)
     int m_exportLevel = 0;
+
+    @Parameter(names= { "-b", "--book"}, description="Comma separated list of books to export (empty to export all)", validateWith=ValidateBook.class)
+    String m_books = "";
 
     @Parameter(names = { "-r", "--runner" }, description = "Runner to use for error reporting. One of: \"reporting\", \"tracing\" or \"recovering\"", validateWith=ValidateRunner.class)
     String m_parseRunner = "reporting";

--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -41,6 +41,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
+import offeneBibel.parser.BookNameHelper;
 import offeneBibel.parser.ObAstFixuper;
 import offeneBibel.parser.ObAstNode;
 import offeneBibel.parser.ObVerseStatus;
@@ -287,6 +288,12 @@ public class Exporter
      */
     private List<Book> retrieveBooks() throws IOException
     {
+        List<String> bookFilter = new ArrayList<String>();
+        if (m_commandLineArguments.m_books.length() > 0) {
+            for(String bookName : m_commandLineArguments.m_books.split(",")) {
+                bookFilter.add(BookNameHelper.getInstance().getUnifiedBookNameForString(bookName));
+            }
+        }
         List<List<String>> bookDataList = Misc.readCsv(m_bibleBooks);
         List<Book>  bookDataCollection = new Vector<Book>();
         for(List<String> bookData : bookDataList) {
@@ -296,6 +303,10 @@ public class Exporter
             book.urlName = book.wikiName.replaceAll(" ", "_");
             book.osisName = bookData.get(1);
             book.chapterCount = Integer.parseInt(bookData.get(2));
+
+            if (bookFilter.size() > 0 && !bookFilter.contains(book.osisName)) {
+                continue;
+            }
 
             for(int i = 1; i <= book.chapterCount; ++i) {
                 Chapter chapter = new Chapter(book, i);

--- a/src/main/java/offeneBibel/parser/OffeneBibelParser.java
+++ b/src/main/java/offeneBibel/parser/OffeneBibelParser.java
@@ -591,6 +591,7 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
             OneOrMore(FirstOf(
                 ScriptureText(),
                 Quote(),
+                Sequence(ACTION(isRuleAncestor("Quote")), InnerQuote()),
                 Insertion(),
                 Alternative(),
                 AlternateReading(),

--- a/src/main/java/offeneBibel/zefania/LogosConverter.java
+++ b/src/main/java/offeneBibel/zefania/LogosConverter.java
@@ -242,7 +242,7 @@ public class LogosConverter {
 			} else {
 				Element elem = (Element) node;
 				if (elem.getNodeName().equals("NOTE")) {
-					String content = elem.getTextContent();
+					String content = elem.getTextContent().replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;");
 					verse.append(buildFootnote(content, footnotes));
 				} else if (elem.getNodeName().equals("BR")) {
 					verse.append("<br />");
@@ -268,7 +268,32 @@ public class LogosConverter {
 	}
 
 	private static void parseStyle(StringBuilder content, Element styleElement) {
-		content.append("<span style=\""+styleElement.getAttribute("css")+"\">");
+		String css = styleElement.getAttribute("css");
+		String suffix = "</span>";
+		if (css.contains("osis-style: added;")) {
+			if (!css.contains("zef-hoist-before")) {
+				Text text = (Text) styleElement.getFirstChild();
+				String prefixBracket = "[";
+				if (!text.getNodeValue().startsWith(prefixBracket))
+					prefixBracket = " [";
+				if (!text.getNodeValue().startsWith(prefixBracket))
+					throw new IllegalStateException("Missing bracket at start of addition.");
+				text.setNodeValue(text.getNodeValue().substring(prefixBracket.length()));
+				content.append("<span style=\"font-weight: bold; color:gray;\">" + prefixBracket + "</span>");
+			}
+			if (!css.contains("zef-hoist-after")) {
+				Text text = (Text) styleElement.getLastChild();
+				String suffixBracket = "]";
+				if (!text.getNodeValue().endsWith(suffixBracket))
+					suffixBracket = "] ";
+				if (!text.getNodeValue().endsWith(suffixBracket))
+					throw new IllegalStateException("Missing bracket at end of addition.");
+				text.setNodeValue(text.getNodeValue().substring(0, text.getNodeValue().length() - suffixBracket.length()));
+				suffix += "<span style=\"font-weight: bold; color:gray;\">" + suffixBracket + "</span>";
+			}
+			css = "osis-style:added;";
+		}
+		content.append("<span style=\""+css+"\">");
 		for (Node node = styleElement.getFirstChild(); node != null; node = node.getNextSibling()) {
 			if (node instanceof Text) {
 				String txt = ((Text) node).getTextContent();
@@ -285,7 +310,7 @@ public class LogosConverter {
 				}
 			}
 		}
-		content.append("</span>");
+		content.append(suffix);
 	}
 
 	private static String getVerseMap(String book) {

--- a/src/main/java/util/ValidateBook.java
+++ b/src/main/java/util/ValidateBook.java
@@ -1,0 +1,18 @@
+package util;
+
+import offeneBibel.parser.BookNameHelper;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+
+public class ValidateBook implements IParameterValidator {
+    @Override
+    public void validate(String name, String value) throws ParameterException {
+        if (value.length() == 0) return;
+        for(String bookName : value.split(",", -1)) {
+            if (!BookNameHelper.getInstance().isValid(bookName)) {
+                throw new ParameterException("Parameter "+name+" refers to unknown book \""+bookName+"\".");
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Kommandozeilenparameter `-b` (`--book`) um auszuwählen, welche Bücher exportiert werden sollen
- InnerQuotes werden jetzt auch innerhalb von Alternativen (die ihrerseits in einem Quote liegen) erkannt
- Aufhübschen des CSS für den Logos-Export

![Screenshot](https://cloud.githubusercontent.com/assets/1568931/7047465/0174d0ce-de0d-11e4-9931-98e98c6ff269.png)
