### PR TITLE
Html footnotes

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
+++ b/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
@@ -1,5 +1,6 @@
 package offeneBibel.osisExporter;
 
+import util.ValidateBook;
 import util.ValidateLevel;
 import util.ValidateRunner;
 
@@ -8,6 +9,9 @@ import com.beust.jcommander.Parameter;
 class CommandLineArguments {
     @Parameter(names = { "-e", "--exportLevel" }, description = "Required translation status for export, 0=no restrictions on criteria, 7=all criteria met", validateWith=ValidateLevel.class)
     int m_exportLevel = 0;
+
+    @Parameter(names= { "-b", "--book"}, description="Comma separated list of books to export (empty to export all)", validateWith=ValidateBook.class)
+    String m_books = "";
 
     @Parameter(names = { "-r", "--runner" }, description = "Runner to use for error reporting. One of: \"reporting\", \"tracing\" or \"recovering\"", validateWith=ValidateRunner.class)
     String m_parseRunner = "reporting";

--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -41,6 +41,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
+import offeneBibel.parser.BookNameHelper;
 import offeneBibel.parser.ObAstFixuper;
 import offeneBibel.parser.ObAstNode;
 import offeneBibel.parser.ObVerseStatus;
@@ -287,6 +288,12 @@ public class Exporter
      */
     private List<Book> retrieveBooks() throws IOException
     {
+        List<String> bookFilter = new ArrayList<String>();
+        if (m_commandLineArguments.m_books.length() > 0) {
+            for(String bookName : m_commandLineArguments.m_books.split(",")) {
+                bookFilter.add(BookNameHelper.getInstance().getUnifiedBookNameForString(bookName));
+            }
+        }
         List<List<String>> bookDataList = Misc.readCsv(m_bibleBooks);
         List<Book>  bookDataCollection = new Vector<Book>();
         for(List<String> bookData : bookDataList) {
@@ -296,6 +303,10 @@ public class Exporter
             book.urlName = book.wikiName.replaceAll(" ", "_");
             book.osisName = bookData.get(1);
             book.chapterCount = Integer.parseInt(bookData.get(2));
+
+            if (bookFilter.size() > 0 && !bookFilter.contains(book.osisName)) {
+                continue;
+            }
 
             for(int i = 1; i <= book.chapterCount; ++i) {
                 Chapter chapter = new Chapter(book, i);

--- a/src/main/java/offeneBibel/parser/OffeneBibelParser.java
+++ b/src/main/java/offeneBibel/parser/OffeneBibelParser.java
@@ -591,6 +591,7 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
             OneOrMore(FirstOf(
                 ScriptureText(),
                 Quote(),
+                Sequence(ACTION(isRuleAncestor("Quote")), InnerQuote()),
                 Insertion(),
                 Alternative(),
                 AlternateReading(),

--- a/src/main/java/offeneBibel/zefania/FootnoteHTMLGrabber.java
+++ b/src/main/java/offeneBibel/zefania/FootnoteHTMLGrabber.java
@@ -1,0 +1,174 @@
+package offeneBibel.zefania;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.Text;
+
+import util.Misc;
+
+public class FootnoteHTMLGrabber {
+
+    private static final String BASE_URL = "http://www.offene-bibel.de/wiki/index.php5?title=";
+
+    private static final Pattern PROLOG_REGEX = Pattern.compile(
+            "\n<div class=\"bemerkungen\">(.*?)\n</div>\n<p></p>\n<table class=\"references\">",
+            Pattern.DOTALL);
+
+    private static final Pattern FOOTNOTE_REGEX = Pattern.compile(
+            "<td class=\"note\" id=\"note_[a-z]++\">(.*?)\n?</td>\n?</tr>\n?(<tr>\n?<td class=\"note_id\">|</table>\n?(<h2>|<div class=\"navi\">|</p>\n?<h2>))",
+            Pattern.DOTALL);
+
+    public static void main(String[] args) throws Exception {
+        convert("offeneBibelStudienfassungZefania");
+        convert("offeneBibelLesefassungZefania");
+    }
+
+    private static String[] WIKI_BOOKS = new String[] {
+            null,
+            "Genesis", "Exodus", "Levitikus", "Numeri", "Deuteronomium",
+            "Josua", "Richter", "Rut", "1_Samuel", "2_Samuel",
+            "1_Könige", "2_Könige", "1_Chronik", "2_Chronik", "Esra",
+            "Nehemia", "Ester", "Ijob", "Psalm", "Sprichwörter",
+            "Kohelet", "Hohelied", "Jesaja", "Jeremia", "Klagelieder",
+            "Ezechiel", "Daniel", "Hosea", "Joel", "Amos",
+            "Obadja", "Jona", "Micha", "Nahum", "Habakuk",
+            "Zefanja", "Haggai", "Sacharja", "Maleachi", "Matthäus",
+            "Markus", "Lukas", "Johannes", "Apostelgeschichte", "Römer",
+            "1_Korinther", "2_Korinther", "Galater", "Epheser", "Philipper",
+            "Kolosser", "1_Thessalonicher", "2_Thessalonicher", "1_Timotheus", "2_Timotheus",
+            "Titus", "Philemon", "Hebräer", "Jakobus", "1_Petrus",
+            "2_Petrus", "1_Johannes", "2_Johannes", "3_Johannes", "Judas",
+            "Offenbarung", "Judit", "Weisheit", "Tobit", "Jesus_Sirach",
+            "Baruch", "1_Makkabäer", "2_Makkabäer"
+    };
+
+    private static void convert(String zefFile) throws Exception {
+        DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        XPath xpath = javax.xml.xpath.XPathFactory.newInstance().newXPath();
+        Document doc = docBuilder.parse(new File(Misc.getResultsDir(), zefFile + ".xml"));
+
+        Node identifier = ((Node) xpath.evaluate("/XMLBIBLE/INFORMATION/identifier", doc, XPathConstants.NODE)).getFirstChild();
+        identifier.setNodeValue(identifier.getNodeValue() + "HtmlFn");
+        for (Node bookNode = doc.getDocumentElement().getFirstChild().getNextSibling(); bookNode != null; bookNode = bookNode.getNextSibling()) {
+            if (bookNode instanceof Text) {
+                if (bookNode.getTextContent().trim().length() > 0)
+                    throw new IOException();
+                continue;
+            }
+            Element bookElement = (Element) bookNode;
+            if (bookElement.getNodeName().equals("INFORMATION"))
+                continue;
+            if (!bookElement.getNodeName().equals("BIBLEBOOK"))
+                throw new IOException(bookElement.getNodeName());
+            String wikiname = WIKI_BOOKS[Integer.parseInt(bookElement.getAttribute("bnumber"))];
+            for (Node chapterNode = bookNode.getFirstChild(); chapterNode != null; chapterNode = chapterNode.getNextSibling()) {
+                if (chapterNode instanceof Text) {
+                    if (chapterNode.getTextContent().trim().length() > 0)
+                        throw new IOException();
+                    continue;
+                }
+                Element chapterElement = (Element) chapterNode;
+                if (!chapterElement.getNodeName().equals("CHAPTER"))
+                    throw new IOException(chapterElement.getNodeName());
+                int cnumber = Integer.parseInt(chapterElement.getAttribute("cnumber"));
+                Map<String, String> htmlFragments = null;
+                for (Node verseNode = chapterElement.getFirstChild(); verseNode != null; verseNode = verseNode.getNextSibling()) {
+                    if (verseNode instanceof Text)
+                        continue;
+                    Element verseElement = (Element) verseNode;
+                    if (verseElement.getNodeName().equals("PROLOG")) {
+                        if (htmlFragments == null)
+                            htmlFragments = grabFragments(wikiname, cnumber);
+                        htmlize(verseElement, htmlFragments);
+                        continue;
+                    } else if (verseElement.getNodeName().equals("VERS")) {
+                        for (Node node = verseElement.getFirstChild(); node != null; node = node.getNextSibling()) {
+                            if (node instanceof Text)
+                                continue;
+                            Element elem = (Element) node;
+                            if (elem.getNodeName().equals("NOTE")) {
+                                String content = elem.getTextContent();
+                                if (content.startsWith("[St"))
+                                    continue;
+                                if (htmlFragments == null)
+                                    htmlFragments = grabFragments(wikiname, cnumber);
+                                htmlize(elem, htmlFragments);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+        transformer.transform(new DOMSource(doc), new StreamResult(new File(Misc.getResultsDir(), zefFile + "MitHtmlFußnoten.xml")));
+    }
+
+    private static void htmlize(Element elem, Map<String, String> htmlFragments) {
+        String textVersion = elem.getTextContent();
+        String htmlVersion = findHTMLVersion(textVersion, htmlFragments);
+        if (htmlVersion != null && !htmlVersion.equals(textVersion)) {
+            while (elem.getFirstChild() != null)
+                elem.removeChild(elem.getFirstChild());
+            elem.appendChild(elem.getOwnerDocument().createTextNode("<html>" + htmlVersion));
+        }
+    }
+
+    private static Map<String, String> grabFragments(String wikiName, int chapter) throws IOException {
+        String result;
+        String fileCacheString = Misc.getPageCacheDir() + wikiName + "_" + chapter + ".html";
+        if (new File(fileCacheString).exists()) {
+            result = Misc.readFile(fileCacheString);
+        }
+        else {
+            result = Misc.retrieveUrl(BASE_URL + URLEncoder.encode(wikiName + "_" + chapter, "UTF-8"));
+            System.out.println("Grabbing " + wikiName + "_" + chapter);
+            Misc.writeFile(result, fileCacheString);
+        }
+        Map<String,String> fragments = new HashMap<String, String>();
+        result = result.replaceAll("[\r\n]++", "\n");
+        for(Pattern regex : Arrays.asList(PROLOG_REGEX, FOOTNOTE_REGEX)) {
+            Matcher m = regex.matcher(result);
+            while (m.find()) {
+                String fragment = m.group(1);
+                fragment = fragment.replaceAll("<span class=\"backlinks\">.*", "");
+                String key = fragment.replaceAll("<span class=\"tooltip\"><span class=\"tooltip_abbr\">(.*?)</span><span class=\"tooltip_tipwrapper\"><span class=\"tooltip_tip\"><span>.*?</span></span></span></span>", "$1");
+                key = key.replaceAll("<[^<>]++>", "").replaceAll("&(#[0-9]+|[a-z]+);", "").replaceAll("[^A-Za-z0-9]++", "");
+                if (key.length() == 0)
+                    continue;
+                fragments.put(key, fragment);
+            }
+        }
+        return fragments;
+    }
+
+    private static String findHTMLVersion(String textVersion, Map<String, String> htmlFragments) {
+        String key = textVersion.replaceAll("(?i)class=[\"a-z0-9]++", "").replaceAll("<[^<>]++>?", "");
+        key = key.replaceAll("[^A-Za-z0-9]++", "");
+        if (htmlFragments.containsKey(key))
+            return htmlFragments.get(key);
+        return null;
+    }
+}

--- a/src/main/java/offeneBibel/zefania/LogosConverter.java
+++ b/src/main/java/offeneBibel/zefania/LogosConverter.java
@@ -28,6 +28,8 @@ public class LogosConverter {
 	public static void main(String[] args) throws Exception {
 		convert("offeneBibelStudienfassungZefania.xml");
 		convert("offeneBibelLesefassungZefania.xml");
+		convert("offeneBibelStudienfassungZefaniaMitHtmlFußnoten.xml");
+		convert("offeneBibelLesefassungZefaniaMitHtmlFußnoten.xml");
 	}
 
 	private static final Pattern xrefPattern = Pattern.compile("([A-Za-z0-9]+) ([0-9]+), ([0-9]+)");
@@ -197,7 +199,10 @@ public class LogosConverter {
 							for (Node node = prolog.getFirstChild(); node != null; node = node.getNextSibling()) {
 								if (node instanceof Text) {
 									String txt = ((Text) node).getTextContent();
-									txt = txt.replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;").replaceAll("[ \t\r\n]+", " ");
+									if (txt.startsWith("<html>"))
+										txt = txt.substring(6).replaceAll("[ \t\r\n]+", " ");
+									else
+										txt = txt.replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;").replaceAll("[ \t\r\n]+", " ");
 									bblx.write(tagForeign(txt));
 								} else {
 									Element elem = (Element) node;
@@ -242,7 +247,11 @@ public class LogosConverter {
 			} else {
 				Element elem = (Element) node;
 				if (elem.getNodeName().equals("NOTE")) {
-					String content = elem.getTextContent().replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;");
+					String txt = elem.getTextContent(), content;
+					if (txt.startsWith("<html>"))
+						content = txt.substring(6);
+					else
+						content = txt.replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;");
 					verse.append(buildFootnote(content, footnotes));
 				} else if (elem.getNodeName().equals("BR")) {
 					verse.append("<br />");

--- a/src/main/java/offeneBibel/zefania/LogosConverter.java
+++ b/src/main/java/offeneBibel/zefania/LogosConverter.java
@@ -242,7 +242,7 @@ public class LogosConverter {
 			} else {
 				Element elem = (Element) node;
 				if (elem.getNodeName().equals("NOTE")) {
-					String content = elem.getTextContent();
+					String content = elem.getTextContent().replace("&", "&amp").replace("<", "&lt;").replace(">", "&gt;");
 					verse.append(buildFootnote(content, footnotes));
 				} else if (elem.getNodeName().equals("BR")) {
 					verse.append("<br />");
@@ -268,7 +268,32 @@ public class LogosConverter {
 	}
 
 	private static void parseStyle(StringBuilder content, Element styleElement) {
-		content.append("<span style=\""+styleElement.getAttribute("css")+"\">");
+		String css = styleElement.getAttribute("css");
+		String suffix = "</span>";
+		if (css.contains("osis-style: added;")) {
+			if (!css.contains("zef-hoist-before")) {
+				Text text = (Text) styleElement.getFirstChild();
+				String prefixBracket = "[";
+				if (!text.getNodeValue().startsWith(prefixBracket))
+					prefixBracket = " [";
+				if (!text.getNodeValue().startsWith(prefixBracket))
+					throw new IllegalStateException("Missing bracket at start of addition.");
+				text.setNodeValue(text.getNodeValue().substring(prefixBracket.length()));
+				content.append("<span style=\"font-weight: bold; color:gray;\">" + prefixBracket + "</span>");
+			}
+			if (!css.contains("zef-hoist-after")) {
+				Text text = (Text) styleElement.getLastChild();
+				String suffixBracket = "]";
+				if (!text.getNodeValue().endsWith(suffixBracket))
+					suffixBracket = "] ";
+				if (!text.getNodeValue().endsWith(suffixBracket))
+					throw new IllegalStateException("Missing bracket at end of addition.");
+				text.setNodeValue(text.getNodeValue().substring(0, text.getNodeValue().length() - suffixBracket.length()));
+				suffix += "<span style=\"font-weight: bold; color:gray;\">" + suffixBracket + "</span>";
+			}
+			css = "osis-style:added;";
+		}
+		content.append("<span style=\""+css+"\">");
 		for (Node node = styleElement.getFirstChild(); node != null; node = node.getNextSibling()) {
 			if (node instanceof Text) {
 				String txt = ((Text) node).getTextContent();
@@ -285,7 +310,7 @@ public class LogosConverter {
 				}
 			}
 		}
-		content.append("</span>");
+		content.append(suffix);
 	}
 
 	private static String getVerseMap(String book) {

--- a/src/main/java/offeneBibel/zefania/ZefaniaConverter.java
+++ b/src/main/java/offeneBibel/zefania/ZefaniaConverter.java
@@ -500,7 +500,7 @@ public class ZefaniaConverter {
                 else
                     parent.insertBefore(parent.getOwnerDocument().createElement("br"), node.getNextSibling());
             }
-            if (Arrays.asList("q", "foreign", "lg", "l").contains(node.getNodeName())) {
+            if (Arrays.asList("q", "foreign", "lg", "l", "hi").contains(node.getNodeName())) {
                 while (node.getFirstChild() != null) {
                     Node child = node.getFirstChild();
                     node.removeChild(child);

--- a/src/main/java/util/ValidateBook.java
+++ b/src/main/java/util/ValidateBook.java
@@ -1,0 +1,18 @@
+package util;
+
+import offeneBibel.parser.BookNameHelper;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+
+public class ValidateBook implements IParameterValidator {
+    @Override
+    public void validate(String name, String value) throws ParameterException {
+        if (value.length() == 0) return;
+        for(String bookName : value.split(",", -1)) {
+            if (!BookNameHelper.getInstance().isValid(bookName)) {
+                throw new ParameterException("Parameter "+name+" refers to unknown book \""+bookName+"\".");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Zefania-XML Fußnoten mit HTML-Inhalt (gegrabbt von der Offene-Bibel-Website)

und Logos-Export angepasst - allerdings mag Logos offenbar keine Tabellen in Fußnoten:

![logos](https://cloud.githubusercontent.com/assets/1568931/7334747/4ec1165c-eb9c-11e4-8369-97752d1f7e0e.png)

Der Pull Request enthält alle Commits von #18, weil der Logos-Exporter-Fix von dort auch hier nötig ist, und alles andere manuelles Mergen bedeuten würde...
