### PR TITLE
OSIS export: Allow Wikitext to contain a quote within italic text. Su…

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
+++ b/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
@@ -132,7 +132,6 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
             String end = ">";
             if (m_unmilestonedLineGroup) {
                 end = " sID=\"" + m_qTagStart + m_qTagCounter + "\"/>";
-                ++m_qTagCounter;
             }
             if(m_quoteCounter>0)
             {
@@ -393,6 +392,7 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
 
             if (m_unmilestonedLineGroup) {
                 m_currentFassung.append("<q marker=\"\" eID=\""+m_qTagStart+m_qTagCounter+"\"/>");
+                ++m_qTagCounter;
             } else {
                 m_currentFassung.append("</q>");
             }

--- a/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
+++ b/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
@@ -137,17 +137,47 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
             if(m_quoteCounter>0)
             {
                 m_quoteCounter++;
-                m_currentFassung.append("»<q level=\"" + m_quoteCounter + "\" marker=\"\"" + end);
+                
+                m_currentFassung.append("»");
+                
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.italics))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("</hi>");          
+                }
+
+                m_currentFassung.append("<q level=\"" + m_quoteCounter + "\" marker=\"\"" + end);
+                
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.italics))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("<hi type=\"italic\">");          
+                }
             }
             else
             {
                 QuoteSearcher quoteSearcher = new QuoteSearcher();
                 node.host(quoteSearcher, false);
+
+                m_currentFassung.append("„");
+
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.italics))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("</hi>");          
+                }
+
                 if(quoteSearcher.foundQuote == false)
-                    m_currentFassung.append("„<q marker=\"\"" + end);
+                    m_currentFassung.append("<q marker=\"\"" + end);
                 else {
                     m_quoteCounter++;
-                    m_currentFassung.append("„<q level=\"" + m_quoteCounter + "\" marker=\"\"" + end);
+                    m_currentFassung.append("<q level=\"" + m_quoteCounter + "\" marker=\"\"" + end);
+                }
+
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.italics))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("<hi type=\"italic\">");          
                 }
             }
         }
@@ -193,6 +223,10 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
         else if(node.getNodeType() == ObAstNode.NodeType.italics) {
             if (m_skipVerse) return;
             m_currentFassung.append("<hi type=\"italic\">");
+        }
+        else if (node.getNodeType() == ObAstNode.NodeType.superScript) {
+            if (m_skipVerse) return;
+            m_currentFassung.append("<hi type=\"super\">");
         }
     }
 
@@ -350,11 +384,25 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
             if(m_skipVerse) return;
             if(m_quoteCounter>0)
                 m_quoteCounter--;
+
+            if (node.getParent().isDescendantOf(ObAstNode.NodeType.italics))
+            {
+                // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                m_currentFassung.append("</hi>");          
+            }
+
             if (m_unmilestonedLineGroup) {
                 m_currentFassung.append("<q marker=\"\" eID=\""+m_qTagStart+m_qTagCounter+"\"/>");
             } else {
                 m_currentFassung.append("</q>");
             }
+
+            if (node.getParent().isDescendantOf(ObAstNode.NodeType.italics))
+            {
+                // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                m_currentFassung.append("<hi type=\"italic\">");          
+            }
+
             if(m_quoteCounter>0)
                 m_currentFassung.append("«");
             else
@@ -401,6 +449,10 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
         }
 
         else if(node.getNodeType() == ObAstNode.NodeType.italics) {
+            if (m_skipVerse) return;
+            m_currentFassung.append("</hi>");
+        }
+        else if(node.getNodeType() == ObAstNode.NodeType.superScript) {
             if (m_skipVerse) return;
             m_currentFassung.append("</hi>");
         }


### PR DESCRIPTION
…perscript added. The Wikitext

```
''„Folge mir nach!“''
```

previously resolved to

```
<hi type="italic">„<q marker="" sID="Mark.2_q_tag_64"/>Folge mir nach!<q marker="" eID="Mark.2_q_tag_64"/>“</hi>
```

As <q/> isn't allowed within <hi/> (reserved for markup of text nodes), this change wraps <hi/> around <q/> like this:

```
<hi type="italic">„</hi><q marker="" sID="Mark.2_q_tag_64"/><hi type="italic">Folge mir nach!</hi><q marker="" eID="Mark.2_q_tag_64"/><hi type="italic">“</hi>
```

Please note that this change only covers OSIS output produced with option --lineGroupUnmilestoned.
