### PR TITLE
Add variation select option for divine names

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
+++ b/src/main/java/offeneBibel/osisExporter/CommandLineArguments.java
@@ -13,6 +13,9 @@ class CommandLineArguments {
     @Parameter(names= { "-b", "--book"}, description="Comma separated list of books to export (empty to export all)", validateWith=ValidateBook.class)
     String m_books = "";
 
+    @Parameter(names= { "-d", "--divineName"}, description="Desired divine name style (0-13)")
+    int m_divineNameStyle = 0;
+
     @Parameter(names = { "-r", "--runner" }, description = "Runner to use for error reporting. One of: \"reporting\", \"tracing\" or \"recovering\"", validateWith=ValidateRunner.class)
     String m_parseRunner = "reporting";
     @Parameter(names = { "-R", "--reloadOnError" }, description = "If parsing fails for a page, redownload it and retry.")

--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -71,12 +71,12 @@ public class Exporter
      * URL prefix to use for retrieving the translation pages.
      */
     //static final String m_urlBase = "http://www.offene-bibel.de/wiki/api.php?action=query&prop=revisions&rvprop=content&format=xml&titles=";
-    static final String m_urlBase = "http://www.offene-bibel.de/wiki/index.php5?action=raw&title=";
+    static final String m_urlBase = "http://www.offene-bibel.de/mediawiki/index.php?action=raw&title=";
 
     /**
      * URL prefix to use for retrieving history of a page.
      */
-    static final String m_historyURLBase = "http://www.offene-bibel.de/wiki/api.php5?action=query&prop=revisions&rvprop=ids|timestamp&rvlimit=100&format=xml&titles=";
+    static final String m_historyURLBase = "http://www.offene-bibel.de/mediawiki/api.php?action=query&prop=revisions&rvprop=ids|timestamp&rvlimit=100&format=xml&titles=";
 
     /**
      * Oldest date for a history page to be considered to be retrieved. Increase it when parsing succeeded to find errors faster.

--- a/src/main/java/offeneBibel/osisExporter/Exporter.java
+++ b/src/main/java/offeneBibel/osisExporter/Exporter.java
@@ -321,6 +321,7 @@ public class Exporter
     private boolean generateAsts(List<Book> books, ObVerseStatus requiredTranslationStatus, boolean stopOnError) throws Throwable
     {
         OffeneBibelParser parser = Parboiled.createParser(OffeneBibelParser.class);
+        parser.setDivineNameStyle(m_commandLineArguments.m_divineNameStyle);
         BasicParseRunner<ObAstNode> parseRunner = new BasicParseRunner<ObAstNode>(parser.Page());
         boolean reloadOnError = m_commandLineArguments.m_reloadOnError;
         StringBuilder errorList = new StringBuilder();


### PR DESCRIPTION
Quick and dirty implementation, but it seems to work better than the
website one (which causes incorrect translations for "der Herr/Ewige" in
case the Ich/Du/Er form is DU).

Default (if no parameter specified) is as before (mixed).

[Psalm 4,7 ist ein gutes Beispiel, wo der Ewige auf der Webseite suboptimal aussieht]
