### PR TITLE
Fixups für den Zefanja-Workflow

### DIFF
--- a/src/main/java/offeneBibel/zefania/ESwordConverter.java
+++ b/src/main/java/offeneBibel/zefania/ESwordConverter.java
@@ -374,6 +374,8 @@ public class ESwordConverter {
             comments.append(marker + "</p>\n");
             cmtx.write(comments.toString());
         }
+        if (verse.toString().trim().equals(vref))
+            verse.append("-");
         return verse.toString();
     }
 

--- a/src/main/java/offeneBibel/zefania/ESwordConverter.java
+++ b/src/main/java/offeneBibel/zefania/ESwordConverter.java
@@ -16,7 +16,9 @@ import util.Misc;
 
 public class ESwordConverter {
 
+    private static String marker;
     public static void main(String[] args) throws Exception {
+        marker = args.length > 0 ? args[0] : "";
         convert("offeneBibelStudienfassungZefania.xml");
         convert("offeneBibelLesefassungZefania.xml");
     }
@@ -224,17 +226,17 @@ public class ESwordConverter {
                     "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n" +
                     "<style>p{margin-top:0pt;margin-bottom:0pt;}</style>\n" +
                     "</head><body>\n" +
-                    "<p>#define description=" + title + "</p>\n" +
-                    "<p>#define abbreviation=" + identifier + "</p>\n" +
-                    "<p>#define comments=" + description + "</p>\n" +
-                    "<p>#define version=1</p>\n" +
-                    "<p>#define strong=0</p>\n" +
-                    "<p>#define right2left=0</p>\n" +
-                    "<p>#define ot=1</p>\n" +
-                    "<p>#define nt=1</p>\n" +
-                    "<p>#define font=DEFAULT</p>\n" +
-                    "<p>#define apocrypha=1</p>\n" +
-                    "<p><span style=\"background-color:#C80000;\">\u00F7</span></p>\n");
+                    "<p>#define description=" + title + marker + "</p>\n" +
+                    "<p>#define abbreviation=" + identifier + marker + "</p>\n" +
+                    "<p>#define comments=" + description + marker + "</p>\n" +
+                    "<p>#define version=1" + marker + "</p>\n" +
+                    "<p>#define strong=0" + marker + "</p>\n" +
+                    "<p>#define right2left=0" + marker + "</p>\n" +
+                    "<p>#define ot=1" + marker + "</p>\n" +
+                    "<p>#define nt=1" + marker + "</p>\n" +
+                    "<p>#define font=DEFAULT" + marker + "</p>\n" +
+                    "<p>#define apocrypha=1" + marker + "</p>\n" +
+                    "<p><span style=\"background-color:#C80000;\">\u00F7</span>" + marker + "</p>\n");
 
             cmtx.write("<html><head>\n" +
                     "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n" +
@@ -243,10 +245,10 @@ public class ESwordConverter {
                     "p.spc{margin-top:10pt;margin-bottom:0pt;}\n" +
                     "p.prologend{border-width:1px;border-top-style:none;border-right-style:none;border-bottom-style:solid;border-left-style:none;border-color:black}" +
                     "</style></head><body>\n" +
-                    "<p>#define description=" + title + " (Kommentar)</p>\n" +
-                    "<p>#define abbreviation=" + identifier + "</p>\n" +
-                    "<p>#define comments=" + description + "</p>\n" +
-                    "<p>#define version=1</p>\r\n");
+                    "<p>#define description=" + title + " (Kommentar)" + marker + "</p>\n" +
+                    "<p>#define abbreviation=" + identifier + marker + "</p>\n" +
+                    "<p>#define comments=" + description + marker + "</p>\n" +
+                    "<p>#define version=1" + marker + "</p>\r\n");
 
             for (Node bookNode = zefDoc.getDocumentElement().getFirstChild().getNextSibling(); bookNode != null; bookNode = bookNode.getNextSibling()) {
                 if (bookNode instanceof Text) {
@@ -290,7 +292,7 @@ public class ESwordConverter {
                         String vref = bname + " " + cnumber + ":" + vnumber;
                         if (invalidVerses.contains(vref))
                             continue;
-                        bblx.write("<p>" + parseVerse(verseElement, vref, cmtx, prolog) + "</p>\n");
+                        bblx.write("<p>" + parseVerse(verseElement, vref, cmtx, prolog) + marker + "</p>\n");
                         prolog = null;
                     }
                 }
@@ -304,7 +306,7 @@ public class ESwordConverter {
     private static String parseVerse(Element verseElement, String vref, BufferedWriter cmtx, Element prologElement) throws IOException {
         boolean hasCommentary = false;
         StringBuilder verse = new StringBuilder(vref + " ");
-        StringBuilder comments = new StringBuilder("<p><span style=\"background-color:#FF0000;\">\u00F7</span>" + vref + "</p>\n<p>");
+        StringBuilder comments = new StringBuilder("<p><span style=\"background-color:#FF0000;\">\u00F7</span>" + vref + marker + "</p>\n<p>");
         if (prologElement != null) {
             for (Node node = prologElement.getFirstChild(); node != null; node = node.getNextSibling()) {
                 if (node instanceof Text) {
@@ -315,7 +317,7 @@ public class ESwordConverter {
                     Element elem = (Element) node;
                     if (elem.getNodeName().equals("STYLE")) {
                         String content = elem.getTextContent();
-                        comments.append("</p>\n<p><i>" + content + "</i></p>\n<p class=\"spc\">");
+                        comments.append(marker + "</p>\n<p><i>" + content + "</i>" + marker + "</p>\n<p class=\"spc\">");
                         hasCommentary = true;
                     } else if (elem.getNodeName().equals("BR")) {
                         comments.append("<br />");
@@ -324,7 +326,7 @@ public class ESwordConverter {
                     }
                 }
             }
-            comments.append("</p>\n<p class=\"prologend\">&nbsp;</p>\n<p class=\"spc\">");
+            comments.append(marker + "</p>\n<p class=\"prologend\">&nbsp;" + marker + "</p>\n<p class=\"spc\">");
             hasCommentary = true;
         }
         for (Node node = verseElement.getFirstChild(); node != null; node = node.getNextSibling()) {
@@ -339,13 +341,13 @@ public class ESwordConverter {
                 Element elem = (Element) node;
                 if (elem.getNodeName().equals("NOTE")) {
                     String content = elem.getTextContent();
-                    comments.append("</p>\n<p>" + content + "</p>\n<p class=\"spc\">");
+                    comments.append(marker + "</p>\n<p>" + content + marker + "</p>\n<p class=\"spc\">");
                     hasCommentary = true;
                 } else if (elem.getNodeName().equals("BR")) {
                     verse.append("<br />");
                     comments.append("<br />");
                 } else if (elem.getNodeName().equals("XREF")) {
-                    comments.append("</p>\n<p class=\"spc\">(Parallelstellen:");
+                    comments.append(marker + "</p>\n<p class=\"spc\">(Parallelstellen:");
                     for(String ref : elem.getAttribute("fscope").split("; ")) {
                         Matcher m = xrefPattern.matcher(ref);
                         if (!m.matches())
@@ -356,7 +358,7 @@ public class ESwordConverter {
                         comments.append(" <span style=\"color:#008000;font-weight:bold;text-decoration:underline;\">");
                         comments.append(book+"_"+m.group(2)+":"+m.group(3)+"</span>");
                     }
-                    comments.append(")</p>\n<p class=\"spc\">");
+                    comments.append(")" + marker + "</p>\n<p class=\"spc\">");
                     hasCommentary = true;
                 } else if (elem.getNodeName().equals("STYLE")) {
                     StringBuilder styleContent = new StringBuilder();
@@ -369,7 +371,7 @@ public class ESwordConverter {
             }
         }
         if (hasCommentary) {
-            comments.append("</p>\n");
+            comments.append(marker + "</p>\n");
             cmtx.write(comments.toString());
         }
         return verse.toString();

--- a/src/main/java/offeneBibel/zefania/FootnoteHTMLGrabber.java
+++ b/src/main/java/offeneBibel/zefania/FootnoteHTMLGrabber.java
@@ -28,7 +28,7 @@ import util.Misc;
 
 public class FootnoteHTMLGrabber {
 
-    private static final String BASE_URL = "http://www.offene-bibel.de/wiki/index.php5?title=";
+    private static final String BASE_URL = "http://www.offene-bibel.de/mediawiki/index.php?title=";
 
     private static final Pattern PROLOG_REGEX = Pattern.compile(
             "\n<div class=\"bemerkungen\">(.*?)\n</div>\n<p></p>\n<table class=\"references\">",

--- a/src/main/java/offeneBibel/zefania/LogosConverter.java
+++ b/src/main/java/offeneBibel/zefania/LogosConverter.java
@@ -145,7 +145,10 @@ public class LogosConverter {
 		try (BufferedWriter bblx = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(new File(Misc.getResultsDir(), identifier + ".logos.html"))))) {
 			bblx.write("<html><head>\n" +
 					"<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n" +
-					"<style>body, h1, h2, h3, h4 { font-family: \"Times New Roman\";}</style>\n"+
+					"<style>\n" +
+					"body, h1, h2, h3, h4 { font-family: \"Times New Roman\";}\n" +
+					"a.sdfootnotesym, a.sdendnotesym { font-style: italic;}\n" +
+					"</style>\n"+
 					"</head><body lang=\"de-DE\">\n" +
 					"<h1>" + title + "</h1>\n" +
 					description + "<br />Lizenz: " + rights + "\n");


### PR DESCRIPTION
Der Converter scheint ja momentan in einem recht schlechten Zustand zu sein (evtl. durch die Änderungen für die Printausgabe des Markusevangeliums) - momentan gibt es alleinstehende `&`-Zeichen (nicht `&amp;`) sowie nicht korrekt verschachtelte Tags im OSIS. Wenn man diese manuell korrigiert, sind wie erwartet wieder ein paar Änderungen am Workflow für Zefanja nötig (primär bedingt durch die veränderte Codierung von Querverweisen).

Diese (relativ ungetestet; es läuft und es kommt ein valides Zefanja-File raus, dieses hab ich aber nicht näher angesehen) hier. 

Des Weiteren 2 "Backports" aus meinem neuen Bibelkonverter-Projekt https://github.com/schierlm/BibleMultiConverter - einer, der ESword-Export stabiler machen kann, und einer, der 2 Warnungen beim Import der Bibel in Logos unterdrückt.

Nebenbei: Mir scheint, wir haben unterschiedliche Vorstellungen, wie stabil Code sein soll, der in einen Master Branch committed wird und was lieber in einem Feature Branch bleiben sollte. Nachdem das auf meiner Seite regelmäßig Frustrationen erzeugt(e), habe ich mich entschlossen, das Projekt nicht weiter zu verfolgen. Dies wird also bis auf weiteres mein vorletzter Pull Request sein (der letzte kommt in ein paar Minuten). Wünsche euch trotzdem allen noch viel Erfolg mit eurem Projekt - und vielleicht funktioniert ja irgendwann™ auch mal der Syntaxcheck auf der Website (und man sieht vorher ob die Chancen gut stehen, jetzt eine gültige Bibel exportieren zu können) und der RSS-Feed für die Kommentare :-)
