### PR TITLE
Some parser fixes

### DIFF
--- a/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
+++ b/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
@@ -146,6 +146,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
                     // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
                     m_currentFassung.append("</hi>");          
                 }
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.fat))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("</hi>");
+                }
 
                 m_currentFassung.append("<q level=\"" + m_quoteCounter + "\" marker=\"\"" + end);
                 
@@ -153,6 +158,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
                 {
                     // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
                     m_currentFassung.append("<hi type=\"italic\">");          
+                }
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.fat))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("<hi type=\"bold\">");
                 }
             }
             else
@@ -167,6 +177,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
                     // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
                     m_currentFassung.append("</hi>");          
                 }
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.fat))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("</hi>");
+                }
 
                 if(quoteSearcher.foundQuote == false)
                     m_currentFassung.append("<q marker=\"\"" + end);
@@ -179,6 +194,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
                 {
                     // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
                     m_currentFassung.append("<hi type=\"italic\">");          
+                }
+                if (node.getParent().isDescendantOf(ObAstNode.NodeType.fat))
+                {
+                    // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                    m_currentFassung.append("<hi type=\"bold\">");
                 }
             }
         }
@@ -224,6 +244,10 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
         else if(node.getNodeType() == ObAstNode.NodeType.italics) {
             if (m_skipVerse) return;
             m_currentFassung.append("<hi type=\"italic\">");
+        }
+        else if(node.getNodeType() == ObAstNode.NodeType.fat) {
+            if (m_skipVerse) return;
+            m_currentFassung.append("<hi type=\"bold\">");
         }
         else if (node.getNodeType() == ObAstNode.NodeType.superScript) {
             if (m_skipVerse) return;
@@ -411,6 +435,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
                 // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
                 m_currentFassung.append("</hi>");          
             }
+            if (node.getParent().isDescendantOf(ObAstNode.NodeType.fat))
+            {
+                // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                m_currentFassung.append("</hi>");
+            }
 
             if (m_unmilestonedLineGroup) {
                 m_currentFassung.append("<q marker=\"\" eID=\""+m_qTagStart+m_qTagCounter+"\"/>");
@@ -423,6 +452,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
             {
                 // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
                 m_currentFassung.append("<hi type=\"italic\">");          
+            }
+            if (node.getParent().isDescendantOf(ObAstNode.NodeType.fat))
+            {
+                // Quotations are not allowed inside of <hi/>, so wrap <hi/> around them.
+                m_currentFassung.append("<hi type=\"bold\">");
             }
 
             if(m_quoteCounter>0)
@@ -471,6 +505,10 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
         }
 
         else if(node.getNodeType() == ObAstNode.NodeType.italics) {
+            if (m_skipVerse) return;
+            m_currentFassung.append("</hi>");
+        }
+        else if(node.getNodeType() == ObAstNode.NodeType.fat) {
             if (m_skipVerse) return;
             m_currentFassung.append("</hi>");
         }

--- a/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
+++ b/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
@@ -233,7 +233,12 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
 
         else if(node.getNodeType() == ObAstNode.NodeType.hebrew) {
             if(m_skipVerse) return;
-            m_currentFassung.append("<foreign xml:lang=\"he\">");
+
+            if (!node.getParent().isDescendantOf(ObAstNode.NodeType.wikiLink))
+            {
+                // foreign are not allowed inside of <a>, so skip them
+                m_currentFassung.append("<foreign xml:lang=\"he\">");
+            }
         }
 
         else if(node.getNodeType() == ObAstNode.NodeType.note) {
@@ -496,7 +501,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
 
         else if(node.getNodeType() == ObAstNode.NodeType.hebrew) {
             if(m_skipVerse) return;
-            m_currentFassung.append("</foreign>");
+            if (!node.getParent().isDescendantOf(ObAstNode.NodeType.wikiLink))
+            {
+                // foreign are not allowed inside of <a>, so skip them
+                m_currentFassung.append("</foreign>");
+            }
         }
 
         else if(node.getNodeType() == ObAstNode.NodeType.note) {

--- a/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
+++ b/src/main/java/offeneBibel/osisExporter/ObOsisGeneratorVisitor.java
@@ -243,11 +243,11 @@ public class ObOsisGeneratorVisitor extends DifferentiatingVisitor<ObAstNode> im
             m_currentFassung.append("<a href=\"");
             if(obWikiLinkNode.isWikiLink())
                 m_currentFassung.append("http://offene-bibel.de/wiki/");
-            m_currentFassung.append(obWikiLinkNode.getLink());
+            m_currentFassung.append(obWikiLinkNode.getLink().replace("&", "&amp;"));
             m_currentFassung.append("\">");
             
             if(obWikiLinkNode.childCount() == 0)
-                m_currentFassung.append(obWikiLinkNode.getLink());
+                m_currentFassung.append(obWikiLinkNode.getLink().replace("&", "&amp;"));
         }
     }
 

--- a/src/main/java/offeneBibel/parser/OffeneBibelParser.java
+++ b/src/main/java/offeneBibel/parser/OffeneBibelParser.java
@@ -655,6 +655,7 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
                      ScriptureText(),
                      Verse(),
                      Quote(),
+                     InnerQuote(),
                      Fat(),
                      Italics(),
                      Insertion(),

--- a/src/main/java/offeneBibel/parser/OffeneBibelParser.java
+++ b/src/main/java/offeneBibel/parser/OffeneBibelParser.java
@@ -462,6 +462,8 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
                 createOrAppendTextNode(match()),
                 "</nowiki>"
             ),
+            // [Jesus] in Lesefassung (Matthäus 17)
+            Sequence("[Jesus]", createOrAppendTextNode("[Jesus]")),
             // Asterisk (Markus 15)
             Sequence("*", createOrAppendTextNode("*")),
             // empty footnotes (Genesis 10, 1Chronik 1, Johannes 15, Jakobus 1)

--- a/src/main/java/offeneBibel/parser/OffeneBibelParser.java
+++ b/src/main/java/offeneBibel/parser/OffeneBibelParser.java
@@ -338,7 +338,7 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
                 OneOrMore(FirstOf(
                         ScriptureText(),
                         Quote(),
-                        Italics(),
+                        //Italics(),
                         Insertion(),
                         Alternative(),
                         AlternateReading(),
@@ -475,7 +475,7 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
                 breakRecursion(),
                 "'''",
                 push(new ObAstNode(ObAstNode.NodeType.fat)),
-                NoteText(new StringVar("'''")),
+                OneOrMore(Sequence(TestNot("</b>"), NoteChar(), createOrAppendTextNode(match()))),
                 "'''",
                 peek(1).appendChild(pop())
             ),


### PR DESCRIPTION
Fix bugs in the parser that prevent it from creating well-formed OSIS (escape `&` in links, fix ambiguity between ending `'''` and starting `''`) or that are needed due to changes on the website.

Also export bold notes as `<hi>` tags, the same way as italic notes are already handled.
