### PR TITLE
Add more status tags

### DIFF
--- a/src/main/java/offeneBibel/parser/OffeneBibelParser.java
+++ b/src/main/java/offeneBibel/parser/OffeneBibelParser.java
@@ -110,6 +110,12 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
     public Rule ChapterTagType(Var<ObChapterTag> chapterTag) {
         return FirstOf(
             Sequence("Lesefassung in Arbeit", chapterTag.get().setTag(ObChapterTag.ChapterTagName.lesefassunginArbeit)),
+            Sequence("Lesefassung folgt später", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassunginArbeit), todo()),
+            Sequence("Ungeprüfte Lesefassung", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassunginArbeit), todo()),
+            Sequence("Lesefassung kann erstellt werden", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassunginArbeit), todo()),
+            Sequence("Zuverlässige Studienfassung", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassungErfuelltDieMeistenKriterien), todo()),
+            Sequence("zuverlässige Studienfassung", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassungErfuelltDieMeistenKriterien), todo()),
+            Sequence("Sehr gute Studienfassung", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassungErfuelltDieMeistenKriterien), todo()),
             Sequence("Studienfassung in Arbeit", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassunginArbeit)),
             Sequence("Lesefassung zu prüfen", chapterTag.get().setTag(ObChapterTag.ChapterTagName.lesefassungZuPruefen)),
             Sequence("Studienfassung zu prüfen", chapterTag.get().setTag(ObChapterTag.ChapterTagName.studienfassungZuPruefen)),
@@ -122,6 +128,10 @@ public class OffeneBibelParser extends BaseParser<ObAstNode> {
         );
     }
     
+    public boolean todo() {
+        return true;
+    }
+
     //(poemstart ws*)? (vers ws*)* '{{Bemerkungen}}';
     public Rule Fassung(ObFassungNode.FassungType fassung, StringVar breaker) {
         return Sequence(


### PR DESCRIPTION
This commit just parses them and probably is only a start for discussing
how they should be handled (I don't know :D).

In particular, these status tags were added:
- Lesefassung folgt später
- Ungeprüfte Lesefassung
- Lesefassung kann erstellt werden
- Zuverlässige Studienfassung
- Sehr gute Studienfassung

When applying this pull request and the other open ones too, the parser can parse current version and generate a well-formed output file (except the status footnotes of the chapters that use one of the new status flags) :-D
